### PR TITLE
fix(regex): fix generating testcases when filter is not applied

### DIFF
--- a/keploy/keploy.go
+++ b/keploy/keploy.go
@@ -320,7 +320,7 @@ func (k *Keploy) put(tcs regression.TestCaseReq) {
 
 	var str = k.cfg.App.Filter
 	reg:= regexp.MustCompile(str.UrlRegex)
-	if reg.FindString(tcs.URI) == "" {
+	if str.UrlRegex!="" && reg.FindString(tcs.URI) == ""{
 		return
 	}
 


### PR DESCRIPTION
fixes the problem of testcases not generating when filter is not specified in Appconfig