### PR TITLE
fix(ksql): adds a nil pointer check in sql.exec to prevent panic

### DIFF
--- a/integrations/ksql/connPrepareContext.go
+++ b/integrations/ksql/connPrepareContext.go
@@ -50,10 +50,14 @@ func (s Stmt) Exec(args []driver.Value) (driver.Result, error) {
 			if result != nil {
 				l, e := result.LastInsertId()
 				drResult.LastInserted = l
-				drResult.LError = e.Error()
+				if e != nil {
+					drResult.LError = e.Error()
+				}
 				ra, e := result.RowsAffected()
 				drResult.RowsAff = ra
-				drResult.RError = e.Error()
+				if e != nil {
+					drResult.RError = e.Error()
+				}
 			}
 		}
 	default:


### PR DESCRIPTION
https://github.com/keploy/keploy/issues/164
Signed-off-by: re-Tick <jain.ritik.1001@gmail.com>