### PR TITLE
docs(readme): add example for elastic-search integration with keploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,6 +392,30 @@ Example for gORM with GCP-Postgres driver:
         }))
     }
 ```
+### 4. Elasticsearch
+The elastic-search client uses http client to do CRUD operations. There is a Transport field in *elasticsearch.config* which allows you to completely replace the default HTTP client used by the package.So, we use *khttp* as an interceptor and assign it to the Transport field.
+Here is an example -
+```go
+import (
+	"net/http"
+	"github.com/elastic/go-elasticsearch/v8"
+	"github.com/keploy/go-sdk/integrations/khttpclient"
+)
+
+func ConnectWithElasticsearch(ctx context.Context) context.Context {
+	interceptor := khttpclient.NewInterceptor(http.DefaultTransport)
+	newClient, err := elasticsearch.NewClient(elasticsearch.Config{
+		Addresses: []string{
+			"http://localhost:9200",
+		},
+		Transport: interceptor,
+	})
+	if err != nil {
+		panic(err)
+	}
+	return context.WithValue(ctx, domain.ClientKey, newClient)
+}
+```
 ## Supported Clients
 ### net/http
 ```go


### PR DESCRIPTION
Signed-off-by: iamskp99 <iamskp99@gmail.com>

This PR is for this issue : https://github.com/keploy/go-sdk/issues/122

The elastic-search client uses HTTP client to do CRUD operations. There is a Transport field in elasticsearch.config which allows you to replace the default HTTP client used by the package ultimately . So, we use khttp as an interceptor and assign it to the Transport field. Therefore, there is no need for integrations.