### PR TITLE
docs : update documentation of elastic-search support for go-sdk

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,7 +420,7 @@ Example for gORM with GCP-Postgres driver:
 ```
 ### 4. Elasticsearch
 The elastic-search client uses http client to do CRUD operations. There is a Transport field in *elasticsearch.config* which allows you to completely replace the default HTTP client used by the package.So, we use *khttp* as an interceptor and assign it to the Transport field.
-Here is an example -
+Here is an example of making elastic search client with keploy's http interceptor -
 ```go
 import (
 	"net/http"
@@ -428,18 +428,20 @@ import (
 	"github.com/keploy/go-sdk/integrations/khttpclient"
 )
 
-func ConnectWithElasticsearch(ctx context.Context) context.Context {
+func ConnectWithElasticsearch(ctx context.Context) *elasticsearch.Client {
+	// integrate http with keploy
 	interceptor := khttpclient.NewInterceptor(http.DefaultTransport)
 	newClient, err := elasticsearch.NewClient(elasticsearch.Config{
 		Addresses: []string{
 			"http://localhost:9200",
 		},
+		// use khttp as custom http client
 		Transport: interceptor,
 	})
 	if err != nil {
 		panic(err)
 	}
-	return context.WithValue(ctx, domain.ClientKey, newClient)
+	return newClient
 }
 ```
 ### 5. Redis


### PR DESCRIPTION
Signed-off-by: iamskp99 <iamskp99@gmail.com>

This PR is for this issue: https://github.com/keploy/go-sdk/issues/122

The domain variable in the example was adding confusion to the developers. Hence, updated the return type of the ConnectWithElasticsearch function to the *elasticsearch.Client.