### PR TITLE
Only reset http request body if it not a `NoBody`

### DIFF
--- a/integrations/khttpclient/httpClient.go
+++ b/integrations/khttpclient/httpClient.go
@@ -108,14 +108,16 @@ func (i Interceptor) RoundTrip(r *http.Request) (*http.Response, error) {
 	var reqBody []byte
 	if r.Body != nil { // Read
 		var err error
-		reqBody, err = ioutil.ReadAll(r.Body)
+		reqBody, err = io.ReadAll(r.Body)
 		if err != nil {
 			// TODO right way to log errors
 			i.log.Error("Unable to read request body", zap.Error(err))
 			return nil, err
 		}
 	}
-	r.Body = ioutil.NopCloser(bytes.NewBuffer(reqBody)) // Reset
+	if r.Body != http.NoBody {
+		r.Body = io.NopCloser(bytes.NewBuffer(reqBody)) // Reset
+	}
 
 	// adds the keploy context stored in Interceptor's ctx field into the http client request context.
 	if _, err := internal.GetState(r.Context()); err != nil && i.kctx != nil {


### PR DESCRIPTION
The mutation of the http request body was causing MiTM detection to trigger on some internal APIs and would result back in a 503.

```
unmarshalling error response invalid character 'u' looking for beginning of value for response body upstream connect error or disconnect/reset before headers. reset reason: connection termination
```