### PR TITLE
fix: passes default mockpath to generate context in keploy initialisation

### DIFF
--- a/keploy/keploy.go
+++ b/keploy/keploy.go
@@ -174,7 +174,7 @@ func New(cfg Config) *Keploy {
 			Mode:      GetMode(),
 			Name:      k.cfg.App.Name,
 			CTX:       context.Background(),
-			Path:      cfg.App.TestPath,
+			Path:      strings.TrimSuffix(cfg.App.MockPath, "/mocks"),
 			OverWrite: true,
 		})
 	}


### PR DESCRIPTION
The current-directory+"/keploy" path is passed to generate context to record async calls during client server setup. This is done in keploy.New to initialise keploy instanse.