### PR TITLE
fix: fetches tcs of an app without any filter

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/jhump/protoreflect v1.14.0
 	github.com/lestrrat-go/jwx v1.2.25
 	github.com/valyala/fasthttp v1.40.0
-	go.keploy.io/server v0.8.0
+	go.keploy.io/server v0.8.2
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -368,8 +368,8 @@ go.keploy.io/server v0.5.6/go.mod h1:/wHYlepZLITJ+MsYnRfRED9K/ENset2JhfzeAqSGnV0
 go.keploy.io/server v0.7.8/go.mod h1:Xm0Zzt2iBRrvoDY7fBMm8M+geV+ZlkknbqKRVjC3K0I=
 go.keploy.io/server v0.7.12/go.mod h1:ch4rD1NCgtxozDHD9yVk+sLHWz5HgefOqrgEdEIgfBQ=
 go.keploy.io/server v0.7.20/go.mod h1:cu/y7NQ8Io1OP2BfMtfFQugYd/UanRvDWpzcyulx/Qo=
-go.keploy.io/server v0.8.0 h1:AN7j3wNoXAPklYu+5KwMZOg57M3eYinI0bOTrhHho7s=
-go.keploy.io/server v0.8.0/go.mod h1:NdVsySEK6BCZdqeqY5eCIMJL01VmfvPIvjxBpBUcsQE=
+go.keploy.io/server v0.8.2 h1:QN+UmD3NQw4gqPKUQPY9X16alFU6XgNa+UpGsSrvcH8=
+go.keploy.io/server v0.8.2/go.mod h1:NdVsySEK6BCZdqeqY5eCIMJL01VmfvPIvjxBpBUcsQE=
 go.mongodb.org/mongo-driver v1.8.3 h1:TDKlTkGDKm9kkJVUOAXDK5/fkqKHJVwYQSpoRfB43R4=
 go.mongodb.org/mongo-driver v1.8.3/go.mod h1:0sQWfOeY63QTntERDJJ/0SuKK0T1uVSgKCuAROlKEPY=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=

--- a/keploy/keploy.go
+++ b/keploy/keploy.go
@@ -107,8 +107,8 @@ type AppConfig struct {
 type Filter struct {
 	AcceptUrlRegex string
 	HeaderRegex    []string
-	Remove   	   []string
-	Replace 	   map[string]string
+	Remove         []string
+	Replace        map[string]string
 	RejectUrlRegex []string
 }
 
@@ -285,7 +285,7 @@ func (k *Keploy) PutRespGrpc(id string, resp GrpcResp) {
 // Capture will capture request, response and output of external dependencies by making Call to keploy server.
 func (k *Keploy) Capture(req regression.TestCaseReq) {
 	// req.Path, _ = os.Getwd()
-	req.Remove = k.cfg.App.Filter.Remove //Setting the Remove field from config
+	req.Remove = k.cfg.App.Filter.Remove   //Setting the Remove field from config
 	req.Replace = k.cfg.App.Filter.Replace //Setting the Replace field from config
 	go k.put(req)
 }
@@ -295,8 +295,7 @@ func (k *Keploy) Test() {
 	// fetch test cases from web server and save to memory
 	k.Log.Info("test starting in " + k.cfg.App.Delay.String())
 	time.Sleep(k.cfg.App.Delay)
-	tcs := k.fetch(models.HTTP)
-	tcs = append(tcs, k.fetch(models.GRPC_EXPORT)...)
+	tcs := k.fetch()
 	total := len(tcs)
 
 	// start a http test run
@@ -756,12 +755,14 @@ func (k *Keploy) newGet(url string) ([]byte, error) {
 	return body, nil
 }
 
-func (k *Keploy) fetch(reqType models.Kind) []models.TestCase {
+// fetch makes a get request to keploy API server and returns array of testcases
+func (k *Keploy) fetch() []models.TestCase {
+
 	var tcs []models.TestCase = []models.TestCase{}
 	pageSize := 25
 
 	for i := 0; ; i += pageSize {
-		url := fmt.Sprintf("%s/regression/testcase?app=%s&offset=%d&limit=%d&testCasePath=%s&mockPath=%s&reqType=%s", k.cfg.Server.URL, k.cfg.App.Name, i, 25, k.cfg.App.TestPath, k.cfg.App.MockPath, reqType)
+		url := fmt.Sprintf("%s/regression/testcase?app=%s&offset=%d&limit=%d&testCasePath=%s&mockPath=%s", k.cfg.Server.URL, k.cfg.App.Name, i, 25, k.cfg.App.TestPath, k.cfg.App.MockPath)
 
 		req, err := http.NewRequest("GET", url, http.NoBody)
 		if err != nil {


### PR DESCRIPTION
Previously, fetch function makes a get call to Keploy API server and returns test cases for an app with `reqType` filter. 

Now, since the filter is removed from the Keploy API server in GetTCS, it should send "reqType" query param in (GET "/regression/testcase").