### PR TITLE
feat: add mockLib feature for keploy-v2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,7 @@ require (
 require (
 	github.com/creasty/defaults v1.6.0
 	github.com/fullstorydev/grpcurl v1.8.7
+	github.com/golang/protobuf v1.5.2
 	go.keploy.io/server v0.8.6
 	google.golang.org/protobuf v1.28.1
 )

--- a/go.sum
+++ b/go.sum
@@ -415,7 +415,6 @@ go.keploy.io/server v0.5.6/go.mod h1:/wHYlepZLITJ+MsYnRfRED9K/ENset2JhfzeAqSGnV0
 go.keploy.io/server v0.7.8/go.mod h1:Xm0Zzt2iBRrvoDY7fBMm8M+geV+ZlkknbqKRVjC3K0I=
 go.keploy.io/server v0.7.12/go.mod h1:ch4rD1NCgtxozDHD9yVk+sLHWz5HgefOqrgEdEIgfBQ=
 go.keploy.io/server v0.7.20/go.mod h1:cu/y7NQ8Io1OP2BfMtfFQugYd/UanRvDWpzcyulx/Qo=
-go.keploy.io/server v0.8.6-0.20230408144107-6942a76b2d25 h1:1pj/1M6OAISVqMITbQqXFBUc3T/mXT5HYAbbD1AkTJs=
 go.keploy.io/server v0.8.6-0.20230408144107-6942a76b2d25/go.mod h1:SGs8n07hQVoxf+TsbuwSoPQKKxgJ8GVQiCTcqiI//d4=
 go.keploy.io/server v0.8.6 h1:czE9jaliyAkMMJcYnMPNuu6tun7UgwFbokxEG95vLN4=
 go.keploy.io/server v0.8.6/go.mod h1:t7BPuZQSiC3PNHZ9dbn3e3VB61HNWwiqVmaRujfDFUg=

--- a/v2/mock/mocklib.go
+++ b/v2/mock/mocklib.go
@@ -1,0 +1,105 @@
+package mock
+
+import (
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/keploy/go-sdk/pkg/keploy"
+	"go.uber.org/zap"
+
+	"fmt"
+	"os"
+)
+
+var (
+	logger *zap.Logger
+)
+
+type Config struct {
+	Mode      keploy.Mode // Keploy mode on which unit test will run. Possible values: MODE_TEST or MODE_RECORD. Default: MODE_TEST
+	TestSuite string      // TestSuite name to record the mock or test the mocks
+	Path      string      // Path in which Keploy "/mocks" will be generated. Default: current working directroy.
+}
+
+func NewContext(conf Config) {
+	var (
+		mode      = keploy.MODE_TEST
+		err       error
+		path      string = conf.Path
+		keployCmd string
+	)
+
+	// use current directory, if path is not provided or relative in config
+	if conf.Path == "" {
+		path, err = os.Getwd()
+		if err != nil {
+			logger.Error("Failed to get the path of current directory", zap.Error(err))
+		}
+	} else if conf.Path[0] != '/' {
+		path, err = filepath.Abs(conf.Path)
+		if err != nil {
+			logger.Error("Failed to get the absolute path from relative conf.path", zap.Error(err))
+		}
+	}
+
+	if conf.TestSuite == "" {
+		logger.Error("Failed to get test suite name")
+	}
+
+	appPid := os.Getpid()
+
+	recordCmd := "sudo -E /usr/local/bin/keploy mockRecord --pid " + strconv.Itoa(appPid) + " --path " + path + " --delay 5" + " --testSuite " + conf.TestSuite
+	testCmd := "sudo -E /usr/local/bin/keploy mockTest --pid " + strconv.Itoa(appPid) + " --path " + path + " --delay 5" + " --testSuite " + conf.TestSuite
+
+	if keploy.Mode(conf.Mode).Valid() {
+		mode = keploy.Mode(conf.Mode)
+	} else {
+		logger.Error("Failed to get mode")
+	}
+
+	if mode == keploy.MODE_TEST {
+		keployCmd = testCmd
+	} else {
+		keployCmd = recordCmd
+	}
+
+	parts := strings.Fields(keployCmd)
+	cmd := exec.Command(parts[0], parts[1:]...)
+	// cmd.Stdout = os.Stdout
+	// cmd.Stderr = os.Stderr
+	go func() {
+		err := cmd.Run()
+		if err != nil {
+			logger.Error("Failed to run command: %v\n", zap.Error(err))
+			return
+		}
+	}()
+	time.Sleep(20 * time.Second)
+}
+
+func KillProcessOnPort() {
+	port := 16789
+	cmd := exec.Command("sudo", "lsof", "-t", "-i:"+strconv.Itoa(port))
+	output, err := cmd.Output()
+	if err != nil {
+		logger.Error("Failed to execute lsof: %v\n", zap.Error(err))
+		return
+	}
+	appPid := os.Getpid()
+	pids := strings.Split(strings.Trim(string(output), "\n"), "\n")
+	for _, pid := range pids {
+		if pid != strconv.Itoa(appPid) {
+			forceKillProcessByPID(pid)
+		}
+	}
+}
+
+func forceKillProcessByPID(pid string) {
+	cmd := exec.Command("sudo", "kill", "-9", pid)
+	if err := cmd.Run(); err != nil {
+		logger.Error(fmt.Sprintf("Failed to kill process with PID %s:", pid), zap.Error(err))
+	}
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -130,6 +130,7 @@ github.com/goccy/go-json/internal/encoder/vm_indent
 github.com/goccy/go-json/internal/errors
 github.com/goccy/go-json/internal/runtime
 # github.com/golang/protobuf v1.5.2
+## explicit
 github.com/golang/protobuf/jsonpb
 github.com/golang/protobuf/proto
 github.com/golang/protobuf/protoc-gen-go/descriptor


### PR DESCRIPTION
## Related Issue
 Add support for recording stubs using go-sdk in  keploy v2 for using in unit tests

Closes: #726 

#### Describe the changes you've made
Created a function ```NewContext``` which will take all the parameters like mode , path, testSuite name, pid etc . This function should be added before every unit test and once the unit test start this function executes . This function gets the pid of the unit test and execute mockRecord or mockTest command from keploy and mocking happens and at the end of the test keploy needs to be killed unit test run won't stop . So there is an other function ```KillProcessOnPort``` which kills it .

In this way we can support recording stubs in unit tests

## Type of change

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Please let us know if any test cases are added

following is the unit test that I have added and tested for [gin-mongo](https://github.com/keploy/samples-go/tree/samples-ebpf) app 

```
package main

import (
	"bytes"
	"encoding/json"
	"fmt"
	"net/http"
	"net/http/httptest"
	"testing"

	"github.com/gin-gonic/gin"
	"github.com/keploy/go-sdk/keploy"
	"github.com/keploy/go-sdk/v2/mock"
)

func setup() {
	mock.NewContext(mock.Config{
		TestSuite:        "test-set-5",
		Mode:             keploy.MODE_RECORD,
		Path:             "/home/ubuntu/dont_touch/samples-go/gin-mongo",
		EnableKeployLogs: true,
	})
	dbName, collection := "keploy", "url-shortener"
	client, err := New("localhost:27017", dbName)
	if err != nil {
		panic("Failed to initialize MongoDB: " + err.Error())
	}
	db := client.Database(dbName)
	col = db.Collection(collection)
}

func TestGetURL(t *testing.T) {
	setup()
	// Setting up Gin and routes
	r := gin.Default()
	r.GET("/:param", getURL)
	r.POST("/url", putURL)

	// Assuming we already have a shortened URL stored with the hash "test123"
	req, err := http.NewRequest(http.MethodGet, "https://www.example.com/Lhr4BWAi", nil)
	if err != nil {
		t.Fatalf("Couldn't create request: %v\n", err)
	}

	w := httptest.NewRecorder()

	r.ServeHTTP(w, req)

	// We're just checking if it can successfully redirect
	if w.Code != http.StatusSeeOther {
		t.Fatalf("Expected HTTP 303 See Other, but got %v", w.Code)
	}

	mock.KillProcessOnPort()

}

func TestPutURL(t *testing.T) {

	r := gin.Default()
	r.GET("/:param", getURL)
	r.POST("/url", putURL)

	data := map[string]string{
		"url": "https://www.example.com",
	}
	payload, err := json.Marshal(data)
	if err != nil {
		t.Fatalf("rre: %v\n", err)
	}

	req, err := http.NewRequest(http.MethodPost, "/url", bytes.NewBuffer(payload))
	if err != nil {
		t.Fatalf("Couldn't create request: %v\n", err)
	}
	req.Header.Set("Content-Type", "application/json")

	w := httptest.NewRecorder()
	r.ServeHTTP(w, req)

	// Checking if the URL was successfully shortened and stored
	if w.Code != http.StatusOK {
		t.Fatalf("Expected HTTP 200 OK, but got %v", w.Code)
	}

	var response map[string]interface{}
	err = json.Unmarshal(w.Body.Bytes(), &response)
	if err != nil {
		t.Fatalf("Failed to unmarshal response: %v\n", err)
	}
	fmt.Println("response-url" + response["url"].(string))

	if response["url"] == nil || response["ts"] == nil {
		t.Fatalf("Response did not contain expected fields")
	}
}
```
#### Describe if there is any unusual behaviour of your code(Write `NA` if there isn't)
A clear and concise description of it.

## Checklist:
<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

## Screenshots (if any)

<img width="486" alt="Screenshot 2023-08-22 at 2 10 02 AM" src="https://github.com/keploy/go-sdk/assets/72094895/693a1551-9c37-4017-b3e6-e373ddf71a8c">
