### PR TITLE
fix: updates the path to keploy binary in serve cmd

### DIFF
--- a/keploy/keploy.go
+++ b/keploy/keploy.go
@@ -108,8 +108,7 @@ func RunKeployServer(pid int64, delay int, testPath string, port int) error {
 
 	cmd := exec.Command(
 		"sudo",
-		"/home/ritikjain.linux/keploy-workspace/keploy/keploy",
-		// "/usr/local/bin/keploy",
+		"/usr/local/bin/keploy",
 		"serve",
 		fmt.Sprintf("--pid=%d", pid),
 		fmt.Sprintf("-p=%s", testPath),


### PR DESCRIPTION
The path to the keploy binary should be the installed binary